### PR TITLE
Correct name for sudo file when is sudo granting for group

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -55,7 +55,7 @@
 - name: Apply sudoers user configuration
   template:
     src: 'etc-sudoers.d-user_template.j2'
-    dest: "{{ sudo_sudoersd_dir }}/20{{ item.name }}"
+    dest: "{{ sudo_sudoersd_dir }}/20{{ item.name if not item.name.startswith('%') else item.name[1:] }}"
     owner: root
     group: root
     mode: 0440


### PR DESCRIPTION
remove '%' from filename in sudo_sudoersd_dir for group