### PR TITLE
Created temporary files and check before copying to temp

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ one easy to use role.
 - Root privileges, eg `become: yes`
 
 ## Role Variables
-
 | Variable                        | Description                                               | Default value                 |
 |---------------------------------|-----------------------------------------------------------|-------------------------------|
-| `sudo_package`                  | Install sudo if not available                             | `yes`                         |
+| `sudo_visudo`                   | Path to visudo or other sudo syntax check                 | `/sbin/visudo`                |
+| `sudo_package_name`             | Package name to install                                   | `sudo`                        |
 | `sudo_list`                     | List of users and their sudo settings **(see details!)**  | `[]`                          |
 | `sudo_list_host`                | List of users and their sudo settings **(see details!)**  | `[]`                          |
 | `sudo_list_group`               | List of users and their sudo settings **(see details!)**  | `[]`                          |
@@ -47,6 +47,7 @@ one easy to use role.
 | `sudo_runas_aliases`            | List of run as aliases **(see details!)**                 | `[]`                          |
 | `sudo_cmnd_aliases`             | List of command aliases **(see details!)**                | `[]`                          |
 | `sudo_sudoersd_dir`             | Sudoers.d directory                                       | '/etc/sudoers.d'              |
+| `sudo_sudoersd_dir_purge`       | Sudoers.d directory purge files or not (boolean)          | 'false'                       |
 
 #### `sudo_defaults` details
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,9 @@
 ---
-# Install sudo if not available?
-sudo_package: yes
+# command to verify sudoers
+sudo_visudo: /sbin/visudo
+
+# name of package to install
+sudo_package_name: sudo
 
 # list of sudo users
 sudo_list: []
@@ -43,3 +46,6 @@ sudo_cmnd_aliases: []
 
 # Sudoersd directory
 sudo_sudoersd_dir: /etc/sudoers.d
+
+# delete all files in sudoersd directory
+sudo_sudoersd_dir_purge: False

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -21,13 +21,4 @@ galaxy_info:
 
 allow_duplicates: yes
 
-dependencies:
-  - role: GROG.package
-    version: v1.2.3
-    package_state: present
-    package_list:
-      - name: sudo
-    package_list_host: []
-    package_list_group: []
-    when: >
-      (sudo_package|string in 'True,true,Yes,yes')
+dependencies: []

--- a/meta/requirements.yml
+++ b/meta/requirements.yml
@@ -1,2 +1,0 @@
-- src: GROG.package
-  version: v1.2.2

--- a/tasks/cleanup.yml
+++ b/tasks/cleanup.yml
@@ -1,0 +1,3 @@
+---
+- name: Cleanup Temporary directory
+  file: path={{ tempdir.stdout_lines[0] }} state=absent

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -102,7 +102,7 @@
       replace: ''
 
   - name: Purge and copy sudo files
-    shell: "rm -Rvf {{sudo_sudoersd_dir}}/* ; cp -Rv {{ tempdir.stdout_lines[0] }}/* /etc/"
+    shell: "rm -Rvf {{sudo_sudoersd_dir}}/* ; cp -Rv {{ tempdir.stdout_lines[0] }}/* /"
     when: sudo_sudoersd_dir_purge
     register: sudocopy
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,6 @@
 ---
+- name: "Install package {{ sudo_package_name }}"
+  package: name={{ sudo_package_name}} state=present
 
 - name: Make sure sudoers.d dir is available
   file:
@@ -8,74 +10,113 @@
     group: root
     mode: 0750
 
-- name: Restore default sudoers file
-  copy:
-    backup: yes
-    src: "{{ sudo_default_sudoers_src_path }}"
-    dest: '/etc/sudoers'
-    owner: root
-    group: root
-    mode: 0440
-    validate: visudo -cf %s
-  when: sudo_default_sudoers|string in 'True.true.Yes.yes'
-    # Checked as string to make sure it can be specified from the command line.
+- name: Verify original sudoers configuration
+  shell: "{{ sudo_visudo }} -cf /etc/sudoers"
+  register: origsudoers
 
-- name: Enable sudoers.d
-  lineinfile:
-    backup: yes
-    create: yes
-    dest: '/etc/sudoers'
-    line: "#includedir {{ sudo_sudoersd_dir }}"
-    regexp: '^#includedir .*'
-    validate: visudo -cf %s
+- block:
+  - name: Temporary sudoers configuration directory
+    shell: mktemp -d
+    register: tempdir
+  
+  - name: Temporary sudoers.d dir is available
+    file:
+      path: "{{ tempdir.stdout_lines[0] }}/{{ sudo_sudoersd_dir }}"
+      state: directory
+      owner: root
+      group: root
+      mode: 0700
 
-- name: Apply sudoers defaults configuration
-  template:
-    src: 'etc-sudoers.d-defaults_template.j2'
-    dest: "{{ sudo_sudoersd_dir }}/00defaults"
-    owner: root
-    group: root
-    mode: 0440
-    validate: visudo -cf %s
-  when: sudo_defaults|length > 0
+  - name: Temporary make sudoers includeonly
+    lineinfile:
+      backup: yes
+      create: yes
+      dest: "{{ tempdir.stdout_lines[0] }}/etc/sudoers"
+      line: "#includedir {{ tempdir.stdout_lines[0] }}/{{ sudo_sudoersd_dir }}"
+      regexp: '^#includedir .*'
 
-- name: Apply sudoers aliases configuration
-  template:
-    src: 'etc-sudoers.d-aliases_template.j2'
-    dest: "{{ sudo_sudoersd_dir }}/10aliases"
-    owner: root
-    group: root
-    mode: 0440
-    validate: visudo -cf %s
-  when: ( (sudo_host_aliases|length > 0) or
-          (sudo_user_aliases|length > 0) or
-          (sudo_runas_aliases|length > 0) or
-          (sudo_cmnd_aliases|length > 0) )
+  - name: Temporary apply sudoers defaults configuration
+    template:
+      src: 'etc-sudoers.d-defaults_template.j2'
+      dest: "{{ tempdir.stdout_lines[0] }}/{{ sudo_sudoersd_dir }}/00defaults"
+      owner: root
+      group: root
+      mode: 0440
+    when: sudo_defaults|length > 0
 
-- name: Apply sudoers group configuration
-  template:
-    src: 'etc-sudoers.d-group_template.j2'
-    dest: "{{ sudo_sudoersd_dir }}/10{{ item.name }}"
-    owner: root
-    group: root
-    mode: 0440
-    validate: visudo -cf %s
-  when: item.sudo is defined
-  with_flattened:
-    - "{{ sudo_grouplist }}"
-    - "{{ sudo_grouplist_group }}"
-    - "{{ sudo_grouplist_host }}"
+  - name: Temporary apply sudoers aliases configuration
+    template:
+      src: 'etc-sudoers.d-aliases_template.j2'
+      dest: "{{ tempdir.stdout_lines[0] }}/{{ sudo_sudoersd_dir }}/10aliases"
+      owner: root
+      group: root
+      mode: 0440
+    when: ( (sudo_host_aliases|length > 0) or
+            (sudo_user_aliases|length > 0) or
+            (sudo_runas_aliases|length > 0) or
+            (sudo_cmnd_aliases|length > 0) )
 
-- name: Apply sudoers user configuration
-  template:
-    src: 'etc-sudoers.d-user_template.j2'
-    dest: "{{ sudo_sudoersd_dir }}/20{{ item.name }}"
-    owner: root
-    group: root
-    mode: 0440
-    validate: visudo -cf %s
-  when: item.sudo is defined
-  with_flattened:
-    - "{{ sudo_list }}"
-    - "{{ sudo_list_group }}"
-    - "{{ sudo_list_host }}"
+  - name: Temporary apply sudoers group configuration
+    template:
+      src: 'etc-sudoers.d-group_template.j2'
+      dest: "{{ tempdir.stdout_lines[0] }}/{{ sudo_sudoersd_dir }}/10{{ item.name }}"
+      owner: root
+      group: root
+      mode: 0440
+    when: item.sudo is defined
+    with_flattened:
+      - "{{ sudo_grouplist }}"
+      - "{{ sudo_grouplist_group }}"
+      - "{{ sudo_grouplist_host }}"
+
+  - name: Temporary apply sudoers user configuration
+    template:
+      src: 'etc-sudoers.d-user_template.j2'
+      dest: "{{ tempdir.stdout_lines[0] }}/{{ sudo_sudoersd_dir }}/20{{ item.name }}"
+      owner: root
+      group: root
+      mode: 0440
+    when: item.sudo is defined
+    with_flattened:
+      - "{{ sudo_list }}"
+      - "{{ sudo_list_group }}"
+      - "{{ sudo_list_host }}"
+
+  - name: Temporary sudoers integrity check
+    shell: "{{ sudo_visudo }} -cf {{ tempdir.stdout_lines[0]}}/etc/sudoers"
+    register: visudocheck
+
+  - debug: var=visudocheck
+
+  rescue:
+
+    - debug: msg="Temporary sudoers integrity check failed NOT PERFORMING CHANGES!"
+
+    - name: Cleanup
+      include: cleanup.yml
+- block:
+  - name: Remove temporary path make sudoers includeonly
+    replace:
+      dest: "{{ tempdir.stdout_lines[0] }}/etc/sudoers"
+      regexp: "{{ tempdir.stdout_lines[0] }}"
+      replace: ''
+
+  - name: Purge and copy sudo files
+    shell: "rm -Rvf {{sudo_sudoersd_dir}}/* ; cp -Rv {{ tempdir.stdout_lines[0] }}/* /etc/"
+    when: sudo_sudoersd_dir_purge
+    register: sudocopy
+
+  - name: Copy sudo files
+    shell: "cp -Rv {{ tempdir.stdout_lines[0] }}/* /"
+    when: not sudo_sudoersd_dir_purge
+    register: sudocopy
+
+  - debug: var=sudocopy
+
+  rescue:
+    - debug: msg="Copy sudo files failed"
+
+  always:
+    - name: Cleanup
+      include: cleanup.yml
+


### PR DESCRIPTION
removed grog.package used native package added logic to create temporary sudoers files and test all at once (otherwise ansible can lock itself out of making the rest of the changes) then copies the temporary files to /etc and cleans up

I ran into an issue in which converting to the new format with multiple files changed before the users it would lock out ansible and therefore fail.