### PR TITLE
Replace @include statement, if found

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,7 +25,7 @@
     create: true
     dest: '/etc/sudoers'
     line: "#includedir {{ sudo_sudoersd_dir }}"
-    regexp: '^#includedir .*'
+    regexp: '^[#@]includedir .*'
     mode: "0750"
     validate: visudo -cf %s
 


### PR DESCRIPTION
Sudo 1.9.1 and newer allow to use `@include` statement in `/etc/sudoers` instead of `#include` statements. When sudoers comes out of the box with a `@include` statement the role added a `#include` line causing entries in the included directory (i.e. `/etc/sudoers.d`) to be processed twice.

Resolves #31