### PR TITLE
Do not change mode of sudoers config file

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,7 +26,7 @@
     dest: '/etc/sudoers'
     line: "#includedir {{ sudo_sudoersd_dir }}"
     regexp: '^[#@]includedir .*'
-    mode: "0750"
+    mode: "0440"
     validate: visudo -cf %s
 
 - name: Apply sudoers defaults configuration


### PR DESCRIPTION
The /etc/sudoers file shipped by distributions uses 0440 permissions.

    -r--r-----. 1 root root 4,3K Jun 20  2023 /etc/sudoers

Prefer not to deviate from the distributions' default.

Resolves #33